### PR TITLE
プロフィール画面とプロフィール変更画面の作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
  *= ./common
  *= ./users/devise
  *= ./users/show
+ *= ./users/edit
  *= require_tree .
  *= require_self
  */

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
  *= ./layouts/navbar
  *= ./common
  *= ./users/devise
+ *= ./users/show
  *= require_tree .
  *= require_self
  */

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/users/edit.scss
+++ b/app/assets/stylesheets/users/edit.scss
@@ -1,0 +1,13 @@
+.profile-form-wrap {
+  background: #fff;
+  padding: 20px;
+  border: 1px solid #e6e6e6;
+}
+
+.profile-form-wrap label {
+  font-weight: bold;
+}
+
+.edit-profile-wrapper {
+  margin-top: 60px;
+}

--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -1,0 +1,33 @@
+.profile-wrap {
+  margin: 40px 0;
+}
+
+.round-img {
+  border-radius: 50%;
+  width: 120px;
+  height: 120px;
+}
+
+.edit-profile-btn {
+  margin: 15px 0 0 15px;
+  font-weight: bold;
+  height: 26px;
+  line-height: 26px;
+  padding: 0 26px;
+  border-color: #dbdbdb;
+  font-size: 14px;
+}
+
+.setting {
+  background-image: image-url("parts4.png");
+  background-repeat: no-repeat;
+  height: 24px;
+  width: 24px;
+  background-color: transparent;
+  margin: 18px 0 0 10px;
+  background-size: 22px !important;
+  border: none;
+  &:hover {
+    cursor: pointer;
+  }
+}

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,12 @@
+class RegistrationsController < Devise::RegistrationsController
+
+  protected
+
+  def update_resource(resource, params)
+    resource.update_without_current_password(params)
+  end
+
+  def after_update_path_for(resource)
+    user_path(resource)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,7 @@
+class UsersController < ApplicationController
+
+  def show
+    @user = User.find_by(id: params[:id])
+  end
+
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,8 @@
 module ApplicationHelper
+  # gravatarの設定
+  def avatar_url(user)
+    return user.profile_photo unless user.profile_photo.nil?
+    gravatar_id = Digest::MD5::hexdigest(user.email).downcase
+    "https://www.gravatar.com/avatar/#{gravatar_id}.jpg"
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,17 @@ class User < ApplicationRecord
           :recoverable, :rememberable, :validatable
 
   validates :name, presence: true, length: { maximum: 50 }
+
+  def update_without_current_password(params, *options)
+    params.delete(:current_password)
+
+    if params[:password].blank? && params[:password_confirmation].blank?
+      params.delete(:password)
+      params.delete(:password_confirmation)
+    end
+
+    result = update_attributes(params, *options)
+    clean_up_passwords
+    result
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,31 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="col-md-offset-2 mb-4 edit-profile-wrapper">
+  <div class="row">
+    <div class="col-md-8 mx-auto">
+      <div class="profile-form-wrap">
+        <%= form_with scope: resource, as: resource_name, url: registration_path(resource_name), local: true, method: :patch do |f| %>
+          <div class="form-group">
+            <%= f.label :name, "名前" %>
+            <%= f.text_field :name, autofocus: true, class: "form-control" %>
+          </div>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+          <div class="form-group">
+            <%= f.label :email, "メールアドレス" %>
+            <%= f.email_field :email, autofocus: true, class: "form-control" %>
+          </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+          <div class="form-group">
+            <%= f.label :password, "パスワード" %>
+            <%= f.password_field :password, autofocus: "off", class: "form-control" %>
+          </div>
+
+          <div class="form-group">
+            <%= f.label :password_confirmation, "パスワードの確認" %>
+            <%= f.password_field :password_confirmation, autofocus: "off", class: "form-control" %>
+          </div>
+
+          <%= f.submit "変更する", class: "btn btn-primary" %>
+        <% end %>
+      </div>
+    </div>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
@@ -16,7 +18,9 @@
     
       <%= render 'partial/flash_messages' %>
 
-      <%= yield %>
+      <div class="container">
+        <%= yield %>
+      </div>
 
       <%= render 'partial/footer' %>
     </div>

--- a/app/views/partial/_navbar.html.erb
+++ b/app/views/partial/_navbar.html.erb
@@ -10,7 +10,7 @@
           <%= link_to "投稿", "#", class: "btn btn-primary" %>
         </li>
         <li>
-          <%= link_to "", "#", class: "nav-link commonNavIcon profile-icon" %>
+          <%= link_to "", user_path(current_user), class: "nav-link commonNavIcon profile-icon" %>
         </li>
       </ul>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,41 @@
+<div class="profile-wrap">
+  <div class="row">
+    <div class="col-md-4 text-center">
+      <%= image_tag avatar_url(@user), class: "round-img" %>
+    </div>
+    <div class="col-md-8">
+      <div class="row">
+        <h1><%= @user.name %></h1>
+
+        <% if @user == current_user %>
+          <%= link_to "プロフィールを編集", edit_user_registration_path, class: "btn btn-outline-dark common-btn edit-profile-btn" %>
+          <button type="button" class="setting" data-toggle="modal" data-target="#exampleModal"></button>
+        <% end %>
+
+        <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+          <div class="modal-dialog" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title" id="exampleModalLabel">設定</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                  <span aria-hidden="true">×</span>
+                </button>
+              </div>
+              <div class="list-group text-center">
+                <%= link_to "サインアウト", destroy_user_session_path, method: :delete, class: "list-group-item list-group-item-action" %>
+                <%= link_to "キャンセル", "#", class: "list-group-item list-group-item-action", "data-dismiss": "modal" %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <% if @user == current_user %>
+        <div class="row">
+          <p>
+            <%= @user.email %>
+          </p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users,
+    controllers: { registrations: 'registrations' }
+
   root 'pages#home'
 
   get '/users/:id', to: 'users#show', as: 'user'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'pages#home'
+
+  get '/users/:id', to: 'users#show', as: 'user'
+  
 end

--- a/db/migrate/20200724025025_add_profile_photo_to_users.rb
+++ b/db/migrate/20200724025025_add_profile_photo_to_users.rb
@@ -1,0 +1,5 @@
+class AddProfilePhotoToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :profile_photo, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_24_015443) do
+ActiveRecord::Schema.define(version: 2020_07_24_025025) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_07_24_015443) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "name", default: "", null: false
+    t.string "profile_photo"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 内容
```
- ユーザコントローラ追加
- ユーザテーブルにprofile_photoカラムを追加
- gravatarの設定
- プロフィール画面の作成
- プロフィール変更画面の作成
- パスワード無しでプロフィール変更ができるように設定を変更
```

## スクリーンショット
| プロフィール画面 |
| ---- |
| ![image](https://user-images.githubusercontent.com/38488055/88361717-f10a1a80-cdb4-11ea-9ad8-95f3c64bcbf9.png) |

| プロフィール変更画面 |
| ---- |
| ![image](https://user-images.githubusercontent.com/38488055/88361768-1860e780-cdb5-11ea-88a3-a7c14871d117.png) |


