### PR TITLE
投稿詳細画面と投稿削除機能の追加

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -81,3 +81,14 @@
   align-items: center;
   line-height: 0;
 }
+
+// 削除アイコン
+.delete-post-icon {
+  background-image: image-url("parts9");
+  background-repeat: no-repeat;
+  width: 20px;
+  height: 20px;
+  background-size: 20px !important;
+  color: #262626;
+  font-size: 20px;
+}

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -48,3 +48,36 @@
   text-decoration: none;
   color: #262626;
 }
+
+// 投稿詳細
+.post-wrap .col-md-8 {
+  padding: 0px;
+}
+
+.card-right {
+  padding: 20px;
+}
+
+.card-right-name {
+  padding-bottom: 10px;
+  border-bottom: 1px solid #e6e6e6;
+  display: flex;
+}
+
+.card-right-comment {
+  padding-bottom: 10px;
+  border-bottom: 1px solid #e6e6e6;
+  height: 320px;
+  overflow: auto;
+}
+
+.postShow-wrap {
+  border: 1px solid #e6e6e6;
+  margin: 40px;
+}
+
+.post-user-name {
+  display: flex;
+  align-items: center;
+  line-height: 0;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -23,6 +23,10 @@ class PostsController < ApplicationController
     @posts = Post.limit(10).includes(:photos, :user).order('created_at DESC')
   end
 
+  def show 
+    @post = Post.find_by(id: params[:id])
+  end
+
   private
 
   def post_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,6 +27,16 @@ class PostsController < ApplicationController
     @post = Post.find_by(id: params[:id])
   end
 
+  def destroy
+    @post = Post.find_by(id: params[:id])
+    if @post.user == current_user
+      flash[:notice] = "投稿が削除されました" if @post.destroy
+    else
+      flash[:alert] = "投稿の削除に失敗しました"
+    end
+    redirect_to root_path
+  end
+
   private
 
   def post_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,7 @@
 class PostsController < ApplicationController
   # ログインユーザのみ
   before_action :authenticate_user!
+  before_action :set_post, only: [:show, :destroy]
 
   def new
     @post = Post.new
@@ -24,11 +25,9 @@ class PostsController < ApplicationController
   end
 
   def show 
-    @post = Post.find_by(id: params[:id])
   end
 
   def destroy
-    @post = Post.find_by(id: params[:id])
     if @post.user == current_user
       flash[:notice] = "投稿が削除されました" if @post.destroy
     else
@@ -41,5 +40,9 @@ class PostsController < ApplicationController
 
   def post_params
     params.require(:post).permit(:caption, photos_attributes: [:image]).merge(user_id: current_user.id)
+  end
+
+  def set_post
+    @post = Post.find_by(id: params[:id])
   end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -12,7 +12,9 @@
           <% end %>
         </div>
 
-        <%= image_tag post.photos.first.image.url(:medium), class: "card-img-top" %>
+        <%= link_to(post_path(post)) do %>
+          <%= image_tag post.photos.first.image.url(:medium), class: "card-img-top" %>
+        <% end %>
 
         <div class="card-body">
           <div class="row parts">
@@ -23,7 +25,7 @@
           <div>
             <span><strong><%= post.user.name %></strong></span>
             <span><%= post.caption %></span>
-            <%= link_to time_ago_in_words(post.created_at).upcase + "前", "#", class: "post-time no-text-decoration" %>
+            <%= link_to time_ago_in_words(post.created_at).upcase + "前", post_path(post), class: "post-time no-text-decoration" %>
             <hr>
             <div class="row parts">
               <form action="#" class="w-100">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,6 +10,12 @@
             title: post.user.name do %>
             <strong><%= post.user.name %></strong>
           <% end %>
+
+          <% if post.user_id == current_user.id %>
+            <%= link_to post_path(post), method: :delete, class: "ml-auto mx-0 my-auto" do %>
+              <div class="delete-post-icon"></div>
+            <% end %>
+          <% end %>
         </div>
 
         <%= link_to(post_path(post)) do %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,37 @@
+<div class="col-md-10 col-md-offset-1 mx-auto postShow-wrap">
+  <div class="row post-wrap">
+    <div class="col-md-8">
+      <div class="card-left">
+        <%= image_tag @post.photos.first.image.url(:medium), class: "card-img-top" %>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="card-right">
+        <div class="card-right-comment">
+          <div class="card-right-name">
+            <%= link_to user_path(@post.user), class: "no-text-decoration" do %>
+              <%= image_tag avatar_url(@post.user), class: "post-profile-icon" %>
+            <% end %>
+            <%= link_to user_path(@post.user), class: "black-color no-text-decoration post-user-name",
+              title: @post.user.name do %>
+              <strong><%= @post.user.name %></strong>
+            <% end %>
+          </div>
+          <div class="m-2">
+            <strong>
+              <%= @post.caption %>
+            </strong>
+          </div>
+          <div class="comment-post-id">
+            <div class="m-2">
+            </div>
+          </div>
+        </div>
+        <div class="row parts">
+        </div>
+        <div class="post-time"><%= time_ago_in_words(@post.created_at).upcase %>前</div>
+        <hr>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -16,6 +16,13 @@
               title: @post.user.name do %>
               <strong><%= @post.user.name %></strong>
             <% end %>
+
+            <% if @post.user_id == current_user.id %>
+              <%= link_to post_path(@post), method: :delete, class: "ml-auto mx-0 my-auto" do %>
+                <div class="delete-post-icon">
+                </div>
+              <% end %>
+            <% end %>
           </div>
           <div class="m-2">
             <strong>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   get '/users/:id', to: 'users#show', as: 'user'
 
-  resources :posts, only: %i(new create index) do
+  resources :posts, only: %i(new create index show) do
     resources :photos, only: %i(create)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   get '/users/:id', to: 'users#show', as: 'user'
 
-  resources :posts, only: %i(new create index show) do
+  resources :posts, only: %i(new create index show destroy) do
     resources :photos, only: %i(create)
   end
 end


### PR DESCRIPTION
## 内容
```
- 投稿詳細画面の作成
- 各投稿の[投稿画像][日時]から投稿詳細に遷移できるよう実装
- 投稿一覧、投稿詳細画面に削除アイコンを設置
```

## スクリーンショット
| 投稿詳細画面 |
| ---- |
| ![image](https://user-images.githubusercontent.com/38488055/88379651-4d356480-cdde-11ea-8ea4-e7848af3ea6d.png) |

### 削除アイコン
| 投稿一覧 | 投稿詳細 |
| ---- | ---- |
| ![image](https://user-images.githubusercontent.com/38488055/88379754-6b02c980-cdde-11ea-98a9-e49fefff03a5.png) | ![image](https://user-images.githubusercontent.com/38488055/88379680-5a525380-cdde-11ea-8943-d44bc715dee9.png) |