### PR TITLE
【FIX】ヘッダーのユーザアイコンからモーダルが出るようにする

### DIFF
--- a/app/views/partial/_navbar.html.erb
+++ b/app/views/partial/_navbar.html.erb
@@ -12,11 +12,28 @@
         </li>
         <!-- プロフィールリンク -->
         <li>
-          <%= link_to user_path(current_user) do %>
+          <%= button_tag :type => "button", :data => { :toggle => "modal", :target => "#exampleModal" }, class: "btn" do %>
             <%= image_tag avatar_url(current_user), class: "post-profile-icon" %>
           <% end %>
         </li>
       </ul>
+    </div>
+    <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="exampleModalLabel">設定</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">×</span>
+            </button>
+          </div>
+          <div class="list-group text-center">
+            <%= link_to "プロフィール", user_path(current_user), class: "list-group-item list-group-item-action" %>
+            <%= link_to "プロフィール設定", edit_user_registration_path, class: "list-group-item list-group-item-action" %>
+            <%= link_to "サインアウト", destroy_user_session_path, method: :delete, class: "list-group-item list-group-item-action" %>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </nav>

--- a/app/views/partial/_navbar.html.erb
+++ b/app/views/partial/_navbar.html.erb
@@ -6,11 +6,15 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ml-md-auto align-items-center">
+        <!-- 投稿ボタン -->
         <li>
           <%= link_to "投稿", new_post_path, class: "btn btn-primary" %>
         </li>
+        <!-- プロフィールリンク -->
         <li>
-          <%= link_to "", user_path(current_user), class: "nav-link commonNavIcon profile-icon" %>
+          <%= link_to user_path(current_user) do %>
+            <%= image_tag avatar_url(current_user), class: "post-profile-icon" %>
+          <% end %>
         </li>
       </ul>
     </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -12,7 +12,7 @@
           <% end %>
 
           <% if post.user_id == current_user.id %>
-            <%= link_to post_path(post), method: :delete, class: "ml-auto mx-0 my-auto" do %>
+            <%= link_to post_path(post), method: :delete, data: {confirm: "削除しますか？"}, class: "ml-auto mx-0 my-auto" do %>
               <div class="delete-post-icon"></div>
             <% end %>
           <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,26 +9,7 @@
 
         <% if @user == current_user %>
           <%= link_to "プロフィールを編集", edit_user_registration_path, class: "btn btn-outline-dark common-btn edit-profile-btn" %>
-          <button type="button" class="setting" data-toggle="modal" data-target="#exampleModal"></button>
         <% end %>
-
-        <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-          <div class="modal-dialog" role="document">
-            <div class="modal-content">
-              <div class="modal-header">
-                <h5 class="modal-title" id="exampleModalLabel">設定</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                  <span aria-hidden="true">×</span>
-                </button>
-              </div>
-              <div class="list-group text-center">
-                <%= link_to "プロフィール", user_path(current_user), class: "list-group-item list-group-item-action" %>
-                <%= link_to "プロフィール設定", edit_user_registration_path, class: "list-group-item list-group-item-action" %>
-                <%= link_to "サインアウト", destroy_user_session_path, method: :delete, class: "list-group-item list-group-item-action" %>
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
       <% if @user == current_user %>
         <div class="row">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,8 +22,9 @@
                 </button>
               </div>
               <div class="list-group text-center">
+                <%= link_to "プロフィール", user_path(current_user), class: "list-group-item list-group-item-action" %>
+                <%= link_to "プロフィール設定", edit_user_registration_path, class: "list-group-item list-group-item-action" %>
                 <%= link_to "サインアウト", destroy_user_session_path, method: :delete, class: "list-group-item list-group-item-action" %>
-                <%= link_to "キャンセル", "#", class: "list-group-item list-group-item-action", "data-dismiss": "modal" %>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## 内容
```
- 詳細画面の設定アイコンを削除
- ヘッダーのユーザアイコンをログインユーザの設定画像に変更
- ヘッダーのユーザアイコンを押すとモーダルが出るように変更
 +
- 投稿削除時にポップを出す
```

## スクリーンショット
### 投稿詳細画面
| 変更前 | 変更後 |
| ---- | ---- |
| ![image](https://user-images.githubusercontent.com/38488055/88450532-af4ba380-ce8a-11ea-9d04-13ffb648ef16.png) | ![image](https://user-images.githubusercontent.com/38488055/88450542-be325600-ce8a-11ea-91c8-cc9231dc06f0.png) |

### ヘッダー
| 変更前 |
| ---- |
|![image](https://user-images.githubusercontent.com/38488055/88450568-e5892300-ce8a-11ea-8b57-a6b04d7135a4.png) |

| 変更後 | 変更後(アイコン押下) |
| ---- | ---- |
| ![image](https://user-images.githubusercontent.com/38488055/88450584-fa65b680-ce8a-11ea-897d-970ee6fbc60a.png) | ![image](https://user-images.githubusercontent.com/38488055/88450590-05b8e200-ce8b-11ea-8f55-96aea46b6ced.png) |

## 課題
```
- モーダル出現後、アイコンの周りにボーダーが出てしまう（CSS問題）
- モーダルを出す形を変えたい（アコーディオンとかが良さそう）
```